### PR TITLE
Updated Twitch API and removed deprecated permission

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ or in the "license" file accompanying this file. This file is distributed on an 
             <div class="row">
                 <div style="display:none" class="auth" class="text-center">
                     <p>First, connect with your Twitch Account:</p>
-                    <a id="auth-link"><img src="http://ttv-api.s3.amazonaws.com/assets/connect_dark.png" /></a>
+                    <a id="auth-link">Authorize</a>
                 </div>
                 <div style="display:none" class="socket">
                     <textarea class="ws-output" rows="20" style="font-family:Courier;width:100%"></textarea>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 var clientId = '<YOUR CLIENT ID HERE>'; 
 var redirectURI = '<YOUR REDIRECT URL HERE>';
-var scope = 'user_read+chat_login';
+var scope = 'user_read';
 var ws;
 
 function parseFragment(hash) {
@@ -101,6 +101,7 @@ $(function() {
             url: "https://api.twitch.tv/kraken/user",
             method: "GET",
             headers: {
+                "Accept": "application/vnd.twitchtv.v5+json",
                 "Client-ID": clientId,
                 "Authorization": "OAuth " + sessionStorage.twitchOAuthToken
             }})


### PR DESCRIPTION
Fixes #2 and fixes #3  

Also the img tag for the auth-link was not working, so I replaced it with "Authorize".

Followed migration guide here:
https://dev.twitch.tv/docs/v5/guides/migration